### PR TITLE
Remove padDC4[0x30] from RenderTargetManager

### DIFF
--- a/include/RE/B/BSGraphics.h
+++ b/include/RE/B/BSGraphics.h
@@ -730,28 +730,27 @@ namespace RE
 			RenderTargetProperties        renderTargetData[100];       // 000
 			DepthStencilTargetProperties  depthStencilTargetData[12];  // C80
 			CubeMapRenderTargetProperties cubeMapRenderTargetData[1];  // DA0
-			std::byte                     padDC4[0x30];
-			std::uint32_t                 renderTargetID[100];                            // DC4
-			std::uint32_t                 depthStencilTargetID[12];                       // F54
-			std::uint32_t                 cubeMapRenderTargetID[1];                       // F84
-			float                         dynamicWidthRatio;                              // F88
-			float                         dynamicHeightRatio;                             // F8C
-			float                         lowestWidthRatio;                               // F90
-			float                         lowestHeightRatio;                              // F94
-			float                         ratioIncreasePerSeconds;                        // F98
-			float                         ratioDecreasePerSeconds;                        // F9C
-			float                         movementDelta;                                  // FA0
-			bool                          increaseResolution;                             // FA4
-			bool                          freezeResolution;                               // FA5
+			std::uint32_t                 renderTargetID[100];         // DC4
+			std::uint32_t                 depthStencilTargetID[12];    // F54
+			std::uint32_t                 cubeMapRenderTargetID[1];    // F84
+			float                         dynamicWidthRatio;           // F88
+			float                         dynamicHeightRatio;          // F8C
+			float                         lowestWidthRatio;            // F90
+			float                         lowestHeightRatio;           // F94
+			float                         ratioIncreasePerSeconds;     // F98
+			float                         ratioDecreasePerSeconds;     // F9C
+			float                         movementDelta;               // FA0
+			bool                          increaseResolution;          // FA4
+			bool                          freezeResolution;            // FA5
 			bool                          updateResolutionOnlyWhenMoving;                 // FA6
 			bool                          useDynamicResolutionViewportAsDefaultViewport;  // FA7
 			bool                          isDynamicResolutionCurrentlyActivated;          // FA8
-			std::uint32_t                 nbFramePause;                                   // FAC
-			std::uint32_t                 nbFramesSinceLastIncrease;                      // FB0
-			BSTAtomicValue<std::uint32_t> dynamicResolutionDisabled;                      // FB4
-			Create_T                      create;                                         // FB8
+			std::uint32_t                 nbFramePause;                // FAC
+			std::uint32_t                 nbFramesSinceLastIncrease;   // FB0
+			BSTAtomicValue<std::uint32_t> dynamicResolutionDisabled;   // FB4
+			Create_T                      create;                      // FB8
 		};
-		static_assert(sizeof(RenderTargetManager) == 0xFF0);
+		static_assert(sizeof(RenderTargetManager) == 0xFC0);
 
 		class OcclusionQuery
 		{


### PR DESCRIPTION
while working on upscaling, noticed the 0x30 pad between cubeMapRenderTargetData and renderTargetID shifted all subsequent fields (dynamicWidthRatio, dynamicHeightRatio, etc.) by +0x30 from their actual game offsets. This caused plugins writing to dynamicWidthRatio via the struct to miss the game's real field, breaking dynamic resolution and upscaling viewport on all runtimes.

Verified by runtime memory probing on OG (1.10.163):
- dynamicWidthRatio lives at offset 0xF88, not 0xFB8
- dynamicHeightRatio lives at offset 0xF8C, not 0xFBC
- isDynamicResolutionCurrentlyActivated at 0xFA8, not 0xFD8

sizeof(RenderTargetManager) changes from 0xFF0 to 0xFC0.