### PR TITLE
fix(IDs): correct 4 wrong OG address IDs

### DIFF
--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -2010,7 +2010,7 @@ namespace RE::ID
 
 	namespace TESObjectCONT
 	{
-		inline constexpr REL::ID GetActivateText{ 2917378, 198653 }; // Check
+		inline constexpr REL::ID GetActivateText{ 917378, 2198653 }; // Check
 	}
 
 	namespace TESObjectDOOR

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -581,7 +581,7 @@ namespace RE::ID
 	{
 		inline constexpr REL::ID UnsignedInt{ 694400, 2267950 };
 		inline constexpr REL::ID Float{ 1118937, 2267953 }; // Check
-		inline constexpr REL::ID Float0To1{ 54937, 2267954 }; // Check
+		inline constexpr REL::ID Float0To1{ 1025602, 2267954 }; // Check
 		inline constexpr REL::ID Int{ 1212543, 2267952 }; // Check
 	}
 
@@ -2043,7 +2043,7 @@ namespace RE::ID
 		inline constexpr REL::ID GetHasOwner{ 1016277, 2202622 };
 		inline constexpr REL::ID GetInventoryObjectCount{ 333415, 2200939 };
 		inline constexpr REL::ID GetLinkedRef{ 897287, 2202683 };
-		inline constexpr REL::ID GetLock{ 305507, 2202648 }; // Check
+		inline constexpr REL::ID GetLock{ 930785, 2202648 }; // Check
 		inline constexpr REL::ID GetWeightInContainer{ 1377567, 2201001 };
 		inline constexpr REL::ID HasContainer{ 1213017, 2201022 };
 		inline constexpr REL::ID IsAnOwner{ 933798, 2202635 };
@@ -2153,7 +2153,7 @@ namespace RE::ID
 	namespace UIMessageQueue
 	{
 		inline constexpr REL::ID Singleton{ 82123, 2689091, 4796377 };
-		inline constexpr REL::ID AddMessage{ 133053, 2284929 }; // Check
+		inline constexpr REL::ID AddMessage{ 1182019, 2284929 }; // Check
 	}
 
 	namespace UIUtils


### PR DESCRIPTION
## Summary

Four OG address IDs that resolved to the wrong functions on OG, verified by OG PDB symbol lookup at the resolved RVA.

| Symbol | Old OG | New OG | What old ID actually was | What new ID is |
|---|---:|---:|---|---|
| `BSRandom::Float0To1` | 54937 | 1025602 | `BSRandom::Float0To1Seed(uint)` | `BSRandom::Float0To1(void)` |
| `TESObjectREFR::GetLock` | 305507 | 930785 | `TESObjectREFR::GetLockLevel(void)` | `TESObjectREFR::GetLock(void)` |
| `UIMessageQueue::AddMessage` | 133053 | 1182019 | `UIMessageQueue::AddMessage<RefHandleUIData>(...)` | `UIMessageQueue::AddMessage(BSFixedString&,UI_MESSAGE_TYPE)` |
| `TESObjectCONT::GetActivateText` | 2917378 | 917378 | (not in any address library — leading-2 typo) | `TESObjectCONT::GetActivateText(TESObjectREFR*,BSStringT<...>&)` |

The `TESObjectCONT::GetActivateText` row also had its NG/AE slot fixed: `198653` → `2198653` (also a leading-2 typo; `198653` resolved only in OG, while `2198653` is the value originally introduced in PR #60 and resolves in both NG and AE).

## How

For each row: read OG ID's RVA from \`version.bin\` -> look up PDB symbol at that RVA -> compare with declared name. When mismatched, search the OG PDB for a symbol whose qualified name exactly matches the declared name and reverse-look its RVA back to an OG address library ID. Where exactly one candidate exists, accept it as the fix.

For `TESObjectCONT::GetActivateText` the OG PDB resolves the declared name to RVA \`0x339C60\` -> OG ID \`917378\`; the NG/AE value is the same one that PR #60 originally shipped (\`2198653\`).