### PR TITLE
add inline to ItemIsPowerConnection / ItemIsPowerReceiver

### DIFF
--- a/include/RE/P/PowerUtils.h
+++ b/include/RE/P/PowerUtils.h
@@ -51,14 +51,14 @@ namespace RE
 		};
 		static_assert(sizeof(TraverseConnectionsOptions) == 0x8);
 
-		bool ItemIsPowerConnection(const TESObjectREFR* refr)
+		inline bool ItemIsPowerConnection(const TESObjectREFR* refr)
 		{
 			using func_t = decltype(&PowerUtils::ItemIsPowerConnection);
 			static REL::Relocation<func_t> func{ ID::PowerUtils::ItemIsPowerConnection };
 			return func(refr);
 		}
 
-		bool ItemIsPowerReceiver(const TESObjectREFR* refr)
+		inline bool ItemIsPowerReceiver(const TESObjectREFR* refr)
 		{
 			using func_t = decltype(&PowerUtils::ItemIsPowerReceiver);
 			static REL::Relocation<func_t> func{ ID::PowerUtils::ItemIsPowerReceiver };


### PR DESCRIPTION
## Summary

Two free functions in `include/RE/P/PowerUtils.h` (`ItemIsPowerConnection` and `ItemIsPowerReceiver`) are defined in the header without the `inline` keyword. Any TU that includes the header emits a strong definition; linking two TUs that both include the header fails with `LNK2005` multiply-defined symbol.