### PR TITLE
Add BGSSaveLoadGame and all related classes

### DIFF
--- a/include/RE/B/BGSChangeFlags.h
+++ b/include/RE/B/BGSChangeFlags.h
@@ -1,0 +1,10 @@
+#pragma once
+namespace RE
+{
+	class BGSChangeFlags
+	{
+	public:
+		int iFlags;
+	};
+	static_assert(sizeof(BGSChangeFlags) == 0x4);
+}

--- a/include/RE/B/BGSConstructFormsInAllFilesMap.h
+++ b/include/RE/B/BGSConstructFormsInAllFilesMap.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "RE/B/BSTHashMap.h"
+#include "RE/T/TESFile.h"
+
+namespace RE
+{
+	class ConstructFormData
+	{
+	public:
+		TESForm*     pForm;
+		unsigned int iFlags;
+	};
+	static_assert(sizeof(ConstructFormData) == 0x10);
+
+	class BGSConstructedForms
+	{
+	public:	
+		BSTArray<ConstructFormData, BSTArrayHeapAllocator> FormsArray[3];
+	};
+	static_assert(sizeof(BGSConstructedForms) == 0x48);
+
+	class BGSConstructFormsMap : public BSTHashMap<unsigned int, ConstructFormData>
+	{
+	public:	
+		unsigned int iFlags;
+	};
+	static_assert(sizeof(BGSConstructFormsMap) == 0x38);
+
+	class BGSConstructCellsMap : public BSTHashMap<unsigned int, BGSConstructFormsMap*>
+	{
+	};
+	static_assert(sizeof(BGSConstructCellsMap) == 0x30);
+
+	class BGSConstructCellSubBlocksMap : public BSTHashMap<unsigned int, BGSConstructCellsMap*>
+	{};
+	static_assert(sizeof(BGSConstructCellSubBlocksMap) == 0x30);
+
+	class BGSConstructCellBlocksMap : public BSTHashMap<unsigned int, BGSConstructCellSubBlocksMap*>
+	{
+	public:	
+		BGSConstructFormsMap* pPersistentCell;
+		bool                  bExteriors;
+	};
+	static_assert(sizeof(BGSConstructCellBlocksMap) == 0x40);
+
+	class BGSConstructWorldSpacesMap : public BSTHashMap<unsigned int, BGSConstructCellBlocksMap*>
+	{
+	};
+	static_assert(sizeof(BGSConstructWorldSpacesMap) == 0x30);
+
+
+	class BGSConstructFormsInFileMap : public BSTHashMap<unsigned int, BGSConstructFormsMap*>
+	{
+	public:	
+		BGSConstructCellBlocksMap*  pInteriorCells;
+		BGSConstructWorldSpacesMap* pWorldSpaces;
+		unsigned int                iCount;
+	};
+
+	static_assert(sizeof(BGSConstructFormsInFileMap) == 0x48);
+
+	class BGSConstructFormsInAllFilesMap :
+		RE::BSTHashMap<TESFile*, BGSConstructFormsInFileMap*>
+	{
+	public:	
+		BGSConstructedForms ConstructedForms;
+		unsigned int        iCount;
+	};
+	static_assert(sizeof(BGSConstructFormsInAllFilesMap) == 0x80);
+
+	class BGSReconstructFormsInAllFilesMap : BGSConstructFormsInAllFilesMap {};
+	static_assert(sizeof(BGSReconstructFormsInAllFilesMap) == 0x80);
+}
+

--- a/include/RE/B/BGSFormChanges.h
+++ b/include/RE/B/BGSFormChanges.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "RE/B/BGSChangeFlags.h"
+#include "RE/B/BGSSaveLoadChangesMap.h"
+
+namespace RE
+{
+	class BGSUnloadedFormBuffer
+	{
+	public:
+		BGSSaveLoadBuffer Buffer;
+	};
+	static_assert(sizeof(BGSUnloadedFormBuffer) == 0x8);
+
+	class BGSFormChanges
+	{
+	public:
+		BGSChangeFlags        iChangeFlags;
+		BGSUnloadedFormBuffer UnloadedFormBuffer;
+	};
+	static_assert(sizeof(BGSFormChanges) == 0x10);
+}

--- a/include/RE/B/BGSLoadFormData.h
+++ b/include/RE/B/BGSLoadFormData.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "RE/B/BGSChangeFlags.h"
+#include "RE/B/BGSSaveGameBuffer.h"
+#include "RE/B/BGSSaveLoadFormInfo.h"
+
+namespace RE
+{
+	class BGSLoadFormData
+	{
+	public:		
+		unsigned int        iFormID;
+		unsigned int        uiDataSize;
+		unsigned int        uiUncompressedSize;
+		TESForm*            pForm;
+		BGSChangeFlags      iChangeFlags;
+		BGSChangeFlags      iOldChangeFlags;
+		std::uint16_t		usFlags;
+		BGSSaveLoadFormInfo FormInfo;
+		std::uint8_t        cVersion;
+	};
+	static_assert(sizeof(BGSLoadFormData) == 0x28);
+}

--- a/include/RE/B/BGSLoadGameSubBuffer.h
+++ b/include/RE/B/BGSLoadGameSubBuffer.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "RE/B/BGSSaveLoadBuffer.h"
+
+namespace RE
+{
+	class BGSLoadGameSubBuffer
+	{
+	public:	
+		BGSSaveLoadBuffer Buffer;
+	};
+
+	static_assert(sizeof(BGSLoadGameSubBuffer) == 0x8);
+}

--- a/include/RE/B/BGSSaveLoadChangesMap.h
+++ b/include/RE/B/BGSSaveLoadChangesMap.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "RE/B/BSTHashMap.h"
+#include "RE/B/BSSpinLock.h"
+#include "RE/B/BGSFormChanges.h"
+
+namespace RE
+{
+	class BGSSaveLoadChangesMap : public BSTHashMap<unsigned int, BGSFormChanges>
+	{
+	public:	
+		BSReadWriteLock RWLock;
+	};
+	static_assert(sizeof(BGSSaveLoadChangesMap) == 0x38);
+}

--- a/include/RE/B/BGSSaveLoadFormIDMap.h
+++ b/include/RE/B/BGSSaveLoadFormIDMap.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "RE/B/BSTArray.h"
+#include "RE/B/BSTHashMap.h"
+
+namespace RE
+{
+	class BGSSaveLoadFormIDMap
+	{
+	public:	
+		BSTHashMap<unsigned int, unsigned int> FormIDToIndexMap;
+		BSTHashMap<unsigned int, unsigned int> IndexToFormIDMap;
+		unsigned int iCurrentIndex;
+	};
+
+	static_assert(sizeof(BGSSaveLoadFormIDMap) == 0x68);
+}
+

--- a/include/RE/B/BGSSaveLoadFormInfo.h
+++ b/include/RE/B/BGSSaveLoadFormInfo.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace RE
+{
+	class BGSSaveLoadFormInfo
+	{
+	public:	
+		std::uint8_t cData;
+	};
+
+	static_assert(sizeof(BGSSaveLoadFormInfo) == 0x1);
+}

--- a/include/RE/B/BGSSaveLoadGame.h
+++ b/include/RE/B/BGSSaveLoadGame.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "RE/T/TESFileCollection.h"
+#include "RE/B/BSFixedString.h"
+#include "RE/B/BSTArray.h"
+#include "RE/B/BSPointerHandle.h"
+#include "BGSSaveLoadFormIDMap.h"
+#include "RE/B/BGSSaveLoadReferencesMap.h"
+#include "RE/B/BGSConstructFormsInAllFilesMap.h"
+#include "RE/B/BGSSaveLoadQueuedSubBufferMap.h"
+#include "RE/B/BGSSaveLoadHistory.h"
+#include "RE/B/BGSSaveLoadChangesMap.h"
+#include "RE/B/BGSLoadFormData.h"
+
+namespace RE
+{
+	
+	class BGSSaveLoadGame
+	{
+	public:
+		[[nodiscard]] static BGSSaveLoadGame* GetSingleton()
+		{
+			REL::Relocation<BGSSaveLoadGame**> singleton{ ID::BGSSaveLoadGame::Singleton };
+			return *singleton;
+		}
+
+		bool GetChange(TESForm* form, BGSChangeFlags flags)
+		{
+			using func_t = decltype(&BGSSaveLoadGame::GetChange);
+			static REL::Relocation<func_t> func{ ID::BGSSaveLoadGame::GetChange };
+			return func(this, form, flags);
+		}
+		
+		TESFileCollection SavedFiles;
+		BGSSaveLoadFormIDMap WorldspaceFormIDMap;
+		BSTHashMap<unsigned int, BSPointerHandle<Actor, BSUntypedPointerHandle<21, 5> >> QueuedInitPackageLocationsActorMap;
+		BSTArray<BSPointerHandle<TESObjectREFR, BSUntypedPointerHandle<21, 5> >, BSTArrayHeapAllocator> QueuedMoveToEditorLocationArray;
+		BGSSaveLoadReferencesMap ReferencesMap;
+		BSTHashMap<unsigned int, unsigned int> ChangedFormIDMap;
+		BGSReconstructFormsInAllFilesMap ReconstructForms;
+		BGSSaveLoadQueuedSubBufferMap QueuedSubBuffersMap;
+		BGSSaveLoadFormIDMap FormIDMap;
+		BGSSaveLoadHistory History;
+		BSTArray<BGSLoadFormData*, BSTArrayHeapAllocator> FormDataArray;
+		BGSSaveLoadChangesMap* pChangesMap;
+		BGSSaveLoadChangesMap* pOldChangesMap;
+		unsigned int iGlobalFlags;
+		std::uint8_t cCurrentMinorVersion;
+		BSFixedString SavedGameVersion;
+	};
+	static_assert(sizeof(BGSSaveLoadGame) == 0x370);
+}

--- a/include/RE/B/BGSSaveLoadHistory.h
+++ b/include/RE/B/BGSSaveLoadHistory.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "RE/B/BSTArray.h"
+
+ namespace RE
+ {
+	 class BGSSaveLoadHistory
+	 {
+	 public:	
+		 BSTArray<char*, BSTArrayHeapAllocator> Notes;
+	 };
+	static_assert(sizeof(BGSSaveLoadHistory) == 0x18);
+ }

--- a/include/RE/B/BGSSaveLoadQueuedSubBufferMap.h
+++ b/include/RE/B/BGSSaveLoadQueuedSubBufferMap.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "RE/B/BSTHashMap.h"
+#include "RE/B/BGSLoadGameSubBuffer.h"
+
+
+namespace RE
+{
+	
+	class BGSSaveLoadQueuedSubBufferMap
+	{
+	public:	
+		BSTHashMap<TESForm*, BGSLoadGameSubBuffer> QueuedSubBuffers[3];
+	};
+	static_assert(sizeof(BGSSaveLoadQueuedSubBufferMap) == 0x90);
+}
+

--- a/include/RE/B/BGSSaveLoadReferencesMap.h
+++ b/include/RE/B/BGSSaveLoadReferencesMap.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "RE/B/BSTHashMap.h"
+#include <RE/C/CellAttachDetachEventSource.h>
+
+namespace RE
+{
+	using BGSCellNumericIDArrayMap = RE::BSTHashMap<unsigned int, RE::BSTArray<unsigned int, RE::BSTArrayHeapAllocator>*>;
+	
+	class BGSSaveLoadReferencesMap
+	{
+	public:	
+		BSTHashMap<unsigned int, unsigned int>				MovedReferencesMap;
+		BGSCellNumericIDArrayMap                            InteriorReferencesMap;
+		BSTHashMap<unsigned int, BGSCellNumericIDArrayMap*>	WorldspaceReferencesMap;
+		BSSpinLock                                          Lock;
+	};
+
+	static_assert(sizeof(BGSSaveLoadReferencesMap) == 0x98);
+}

--- a/include/RE/B/BGSUnloadedFromBuffer.h
+++ b/include/RE/B/BGSUnloadedFromBuffer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "RE/B/BGSChangeFlags.h"
+#include "RE/B/BGSSaveGameBuffer.h"
+
+namespace RE
+{
+	class BGSUnloadedFormBuffer
+	{
+	public:
+		BGSSaveLoadBuffer Buffer;
+	};
+	static_assert(sizeof(BGSUnloadedFormBuffer) == 0x8);
+
+}

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -377,6 +377,12 @@ namespace RE::ID
 		inline constexpr REL::VariantID QueueSaveLoadTask{ 1487308, 2228080 };
 	}
 
+	namespace BGSSaveLoadGame
+	{
+		inline constexpr REL::VariantID Singleton{ 177947, 2697789, 2697789 };
+		inline constexpr REL::VariantID GetChange{ 688165, 2227898, 2227898 };
+	}
+
 	namespace BGSScene
 	{
 		inline constexpr REL::VariantID ResetAllSceneActions{ 1356678, 2206864 };


### PR DESCRIPTION
Added the following classes:

New Classes:
- `BGSSaveLoadGame`
- `BGSSaveLoadReferencesMap`
- `BGSSaveLoadFormIDMap`
- `BGSConstructedForms` 
- `BGSConstructFormsMap`
- `BGSConstructCellBlocksMap`
- `BGSConstructFormsInFileMap`
- `BGSConstructFormsInAllFilesMap`
- `BGSReconstructFormsInAllFilesMap`

Could be Type Aliases:
- `BGSCellNumericIDArrayMap`
- `BGSConstructCellsMap`
- `BGSConstructCellSubBlocksMap`
- `BGSConstructWorldSpacesMap`

New IDs (OG/AE): NG same as AE (unverified)
- `BGSSaveLoadGame::Singleton`
- `BGSSaveLoadGame::GetChange`

IDs provided for both OG (1.10.163) and NG versions.