### PR TITLE
Make COMMONLIB_RUNTIMECOUNT define public

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -14,7 +14,7 @@ add_rules("mode.debug", "mode.releasedbg")
 includes("lib/commonlib-shared")
 
 -- override runtime count
-add_defines("COMMONLIB_RUNTIMECOUNT=3")
+add_defines("COMMONLIB_RUNTIMECOUNT=3", { public = true })
 
 -- define targets
 target("commonlibf4", function()


### PR DESCRIPTION
The static lib is built with `COMMONLIB_RUNTIMECOUNT=3`, but the define isn't marked public, so header consumers fall back to the default of 1. That truncates `REL::ID::m_ids[]` to a single slot in the consumer's translation unit, every ID lookup returns slot 0 (the OG ID), and on AE 1.11.191 the OG IDs aren't in the bin, so `IDDB::offset`'s `lower_bound` returns a nearby ID whose offset can land in `.rdata`. Indirect calls then jump into data and AV.

Marking the define `{ public = true }` fixes it.