### PR TITLE
feat: sync libxse 1.11.221 support

### DIFF
--- a/include/F4SE/Version.h
+++ b/include/F4SE/Version.h
@@ -58,6 +58,7 @@ namespace F4SE
 	inline constexpr REL::Version RUNTIME_1_11_159{ 1, 11, 159, 0 };
 	inline constexpr REL::Version RUNTIME_1_11_169{ 1, 11, 169, 0 };
 	inline constexpr REL::Version RUNTIME_1_11_191{ 1, 11, 191, 0 };
+	inline constexpr REL::Version RUNTIME_1_11_221{ 1, 11, 221, 0 };
 
-	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_11_191;
+	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_11_221;
 }

--- a/include/RE/B/BGSInventoryList.h
+++ b/include/RE/B/BGSInventoryList.h
@@ -35,7 +35,7 @@ namespace RE
 
 		inline void AddItem2(TESBoundObject* a_object, std::uint32_t a_count, ExtraDataList* a_extra, std::uint16_t a_flags = 0) noexcept
 		{
-			using func_t = void(*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, ExtraDataList*, std::uint16_t);
+			using func_t = void (*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, ExtraDataList*, std::uint16_t);
 			static REL::Relocation<func_t> func{ ID::BGSInventoryList::AddItem2 };
 			func(this, a_object, a_count, a_extra, a_flags);
 		}
@@ -111,7 +111,7 @@ namespace RE
 
 		inline void RemoveItem1(TESBoundObject* a_object, std::uint32_t a_stackID, std::uint32_t a_count, bool a_manualMerge = false) noexcept
 		{
-			using func_t = void(*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, std::uint32_t, bool);
+			using func_t = void (*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, std::uint32_t, bool);
 			static REL::Relocation<func_t> func{ ID::BGSInventoryList::RemoveItem1 };
 			func(this, a_object, a_stackID, a_count, a_manualMerge);
 		}

--- a/include/RE/B/BGSInventoryList.h
+++ b/include/RE/B/BGSInventoryList.h
@@ -33,7 +33,33 @@ namespace RE
 			return a_lhs == a_rhs;
 		}
 
-		void FindAndWriteStackDataForItem(
+		inline void AddItem2(TESBoundObject* a_object, std::uint32_t a_count, ExtraDataList* a_extra, std::uint16_t a_flags = 0) noexcept
+		{
+			using func_t = void(*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, ExtraDataList*, std::uint16_t);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::AddItem2 };
+			func(this, a_object, a_count, a_extra, a_flags);
+		}
+
+		inline void AddItem2(TESBoundObject* a_object, std::uint32_t a_count, std::uint16_t a_flags = 0) noexcept
+		{
+			AddItem2(a_object, a_count, new ExtraDataList(), a_flags);
+		}
+
+		inline void BuildFromContainer(const TESContainer* a_container)
+		{
+			using func_t = decltype(&BGSInventoryList::BuildFromContainer);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::BuildFromContainer };
+			func(this, a_container);
+		}
+
+		inline void Clear() noexcept
+		{
+			using func_t = decltype(&BGSInventoryList::Clear);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::Clear };
+			func(this);
+		}
+
+		inline void FindAndWriteStackDataForItem(
 			TESBoundObject*                            a_object,
 			BGSInventoryItem::StackDataCompareFunctor& a_compareFunc,
 			BGSInventoryItem::StackDataWriteFunctor&   a_writeFunc,
@@ -45,8 +71,15 @@ namespace RE
 			return func(this, a_object, a_compareFunc, a_writeFunc, a_objCompFn, a_alwaysContinue);
 		}
 
+		[[nodiscard]] inline std::uint32_t FindItemIndex(TESBoundObject* a_object) const noexcept
+		{
+			using func_t = decltype(&BGSInventoryList::FindItemIndex);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::FindItemIndex };
+			return func(this, a_object);
+		}
+
 		// DOES NOT LOCK
-		void ForEachStack(
+		inline void ForEachStack(
 			std::function<bool(BGSInventoryItem&)>                           a_filter,   // return true to iterate stacks
 			std::function<bool(BGSInventoryItem&, BGSInventoryItem::Stack&)> a_continue  // return false to return control from function
 		)
@@ -62,11 +95,30 @@ namespace RE
 			}
 		}
 
-		void BuildFromContainer(const TESContainer* a_container)
+		[[nodiscard]] inline std::uint32_t GetItemCount(TESBoundObject* a_object) const noexcept
 		{
-			using func_t = decltype(&BGSInventoryList::BuildFromContainer);
-			static REL::Relocation<func_t> func{ ID::BGSInventoryList::BuildFromContainer };
-			return func(this, a_container);
+			using func_t = decltype(&BGSInventoryList::GetItemCount);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::GetItemCount };
+			return func(this, a_object);
+		}
+
+		[[nodiscard]] inline std::uint32_t GetQuestItemCount(TESBoundObject* a_object) const noexcept
+		{
+			using func_t = decltype(&BGSInventoryList::GetQuestItemCount);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::GetQuestItemCount };
+			return func(this, a_object);
+		}
+
+		inline void RemoveItem1(TESBoundObject* a_object, std::uint32_t a_stackID, std::uint32_t a_count, bool a_manualMerge = false) noexcept
+		{
+			using func_t = void(*)(BGSInventoryList*, TESBoundObject*, std::uint32_t, std::uint32_t, bool);
+			static REL::Relocation<func_t> func{ ID::BGSInventoryList::RemoveItem1 };
+			func(this, a_object, a_stackID, a_count, a_manualMerge);
+		}
+
+		inline void RemoveItem1(TESBoundObject* a_object, std::uint32_t a_count, bool a_manualMerge = false) noexcept
+		{
+			RemoveItem1(a_object, 0, a_count, a_manualMerge);
 		}
 
 		// members
@@ -80,7 +132,7 @@ namespace RE
 		{
 			using func_t = decltype(&BGSInventoryList::ctor);
 			static REL::Relocation<func_t> func{ ID::BGSInventoryList::ctor };
-			return func(this, a_container, a_owner);
+			func(this, a_container, a_owner);
 		}
 	};
 	static_assert(sizeof(BGSInventoryList) == 0x80);

--- a/include/RE/B/BGSInventoryList.h
+++ b/include/RE/B/BGSInventoryList.h
@@ -121,38 +121,6 @@ namespace RE
 		{
 			RemoveItem1(a_object, 0, a_count, a_manualMerge);
 		}
-		
-		void AddItemWithExtra(TESBoundObject* a_item, uint32_t a_itemCount, ExtraDataList* a_itemExtra,
-			[[maybe_unused]] uint32_t a_unk = 0) noexcept
-		{
-			using func_t = decltype(&BGSInventoryList::AddItemWithExtra);
-			static REL::Relocation<func_t> func{ ID::BGSInventoryList::AddItemWithExtra };
-			return func(this, a_item, a_itemCount, a_itemExtra, a_unk);
-		}
-
-		void AddItem(TESBoundObject* a_item, uint32_t a_itemCount) noexcept
-		{
-			auto& memMgr = MemoryManager::GetSingleton();
-			auto extraList = (ExtraDataList*)memMgr.Allocate(sizeof(ExtraDataList), 16, true);
-			if (!extraList)
-				return;
-
-			ExtraDataList::Create(extraList);
-			return AddItemWithExtra(a_item, a_itemCount, extraList);
-		}
-
-		void RemoveItem(TESBoundObject* a_item, uint32_t a_unk0, uint32_t a_itemCount,
-			[[maybe_unused]] bool a_unk1 = false) noexcept
-		{
-			using func_t = decltype(&BGSInventoryList::RemoveItem);
-			static REL::Relocation<func_t> func{ ID::BGSInventoryList::RemoveItem };
-			return func(this, a_item, a_unk0, a_itemCount, a_unk1);
-		}
-
-		void RemoveItem2(TESBoundObject* a_item, uint32_t a_itemCount) noexcept
-		{
-			return RemoveItem(a_item, 0, a_itemCount);
-		}
 
 		// members
 		BSTArray<BGSInventoryItem> data;          // 58

--- a/include/RE/E/ExtraDataList.h
+++ b/include/RE/E/ExtraDataList.h
@@ -40,7 +40,7 @@ namespace RE
 
 		ExtraDataList()
 		{
-			using func_t = void(*)(ExtraDataList*);
+			using func_t = void (*)(ExtraDataList*);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::Ctor };
 			func(this);
 		}

--- a/include/RE/E/ExtraDataList.h
+++ b/include/RE/E/ExtraDataList.h
@@ -30,19 +30,35 @@ namespace RE
 	public:
 		F4_HEAP_REDEFINE_NEW(ExtraDataList);
 
+		using ComparisonQualifier = bool (*)(const BSExtraData*);
+
 		enum class CLEAR_FOR
 		{
 			kContainer = 0x0,
 			kReference = 0x1
 		};
 
-		void AddExtra(BSExtraData* a_extra)
+		ExtraDataList()
+		{
+			using func_t = void(*)(ExtraDataList*);
+			static REL::Relocation<func_t> func{ ID::ExtraDataList::Ctor };
+			func(this);
+		}
+
+		inline void AddExtra(BSExtraData* a_extra)
 		{
 			const BSAutoWriteLock l{ extraRWLock };
 			extraData.AddExtra(a_extra);
 		}
 
-		TBO_InstanceData* CreateInstanceData(TESBoundObject* a_object, bool a_generateName)
+		inline void CopyList(const ExtraDataList* a_copy) noexcept
+		{
+			using func_t = decltype(&ExtraDataList::CopyList);
+			static REL::Relocation<func_t> func{ ID::ExtraDataList::CopyList };
+			func(this, a_copy);
+		}
+
+		inline TBO_InstanceData* CreateInstanceData(TESBoundObject* a_object, bool a_generateName)
 		{
 			using func_t = decltype(&ExtraDataList::CreateInstanceData);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::CreateInstanceData };
@@ -87,90 +103,96 @@ namespace RE
 		}
 
 		template <detail::ExtraDataListConstraint T>
-		std::unique_ptr<T> RemoveExtra()
+		inline std::unique_ptr<T> RemoveExtra()
 		{
 			return std::unique_ptr<T>{ static_cast<T*>(RemoveExtra(T::TYPE).release()) };
 		}
 
-		bool SetBendableSplineInfo(float* a_thickness, float* a_slack, NiPoint3* a_halfExtents = nullptr, bool* a_detachedEnd = nullptr)
+		inline bool SetBendableSplineInfo(float* a_thickness, float* a_slack, NiPoint3* a_halfExtents = nullptr, bool* a_detachedEnd = nullptr)
 		{
 			using func_t = decltype(&ExtraDataList::SetBendableSplineInfo);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetBendableSplineInfo };
 			return func(this, a_thickness, a_slack, a_halfExtents, a_detachedEnd);
 		}
 
-		void SetDisplayNameFromInstanceData(BGSObjectInstanceExtra* a_instExtra, TESBoundObject* a_object, const BSTSmartPointer<TBO_InstanceData>& a_data)
+		inline void SetCount(std::int16_t a_count) noexcept
+		{
+			using func_t = decltype(&ExtraDataList::SetCount);
+			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetCount };
+			func(this, a_count);
+		}
+
+		inline void SetDisplayNameFromInstanceData(BGSObjectInstanceExtra* a_instExtra, TESBoundObject* a_object, const BSTSmartPointer<TBO_InstanceData>& a_data)
 		{
 			using func_t = decltype(&ExtraDataList::SetDisplayNameFromInstanceData);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetDisplayNameFromInstanceData };
-			return func(this, a_instExtra, a_object, a_data);
+			func(this, a_instExtra, a_object, a_data);
 		}
 
-		void SetOverrideName(const char* a_name)
+		inline void SetOverrideName(const char* a_name)
 		{
 			using func_t = decltype(&ExtraDataList::SetOverrideName);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetOverrideName };
-			return func(this, a_name);
+			func(this, a_name);
 		}
 
-		void SetStartingWorldOrCell(TESForm* a_form)
+		inline void SetStartingWorldOrCell(TESForm* a_form)
 		{
 			using func_t = decltype(&ExtraDataList::SetStartingWorldOrCell);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetStartingWorldOrCell };
-			return func(this, a_form);
+			func(this, a_form);
 		}
 
-		float GetHealthPerc()
+		inline float GetHealthPerc()
 		{
 			using func_t = decltype(&ExtraDataList::GetHealthPerc);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::GetHealthPerc };
 			return func(this);
 		}
 
-		void SetHealthPerc(float a_healthPerc)
+		inline void SetHealthPerc(float a_healthPerc)
 		{
 			using func_t = decltype(&ExtraDataList::SetHealthPerc);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetHealthPerc };
-			return func(this, a_healthPerc);
+			func(this, a_healthPerc);
 		}
 
-		bool ClearFavorite()
+		inline bool ClearFavorite()
 		{
 			using func_t = decltype(&ExtraDataList::ClearFavorite);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::ClearFavorite };
 			return func(this);
 		}
 
-		bool IsFavorite()
+		inline bool IsFavorite()
 		{
 			using func_t = decltype(&ExtraDataList::IsFavorite);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::IsFavorite };
 			return func(this);
 		}
 
-		bool IsDamaged()
+		inline bool IsDamaged()
 		{
 			using func_t = decltype(&ExtraDataList::IsDamaged);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::IsDamaged };
 			return func(this);
 		}
 
-		typedef bool (*ComparisonQualifier)(const BSExtraData*);
-		bool CompareList(const ExtraDataList* a_compare, ComparisonQualifier a_qualifier)
+		inline bool CompareList(const ExtraDataList* a_compare, ComparisonQualifier a_qualifier)
 		{
 			using func_t = decltype(&ExtraDataList::CompareList);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::CompareList };
 			return func(this, a_compare, a_qualifier);
 		}
 
-		void SetFavorite(char a_quickKeyIndex)
+		inline void SetFavorite(char a_quickKeyIndex)
 		{
 			using func_t = decltype(&ExtraDataList::SetFavorite);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::SetFavorite };
-			return func(this, a_quickKeyIndex);
+			func(this, a_quickKeyIndex);
 		}
 
-		BGSPrimitive* GetPrimitive()
+		inline BGSPrimitive* GetPrimitive()
 		{
 			using func_t = decltype(&ExtraDataList::GetPrimitive);
 			static REL::Relocation<func_t> func{ ID::ExtraDataList::GetPrimitive };

--- a/include/RE/E/ExtraDataList.h
+++ b/include/RE/E/ExtraDataList.h
@@ -199,20 +199,6 @@ namespace RE
 			return func(this);
 		}
 
-		void CopyFrom(ExtraDataList* a_extraDataList) noexcept
-		{
-			using func_t = decltype(&ExtraDataList::CopyFrom);
-			static REL::Relocation<func_t> func{ ID::ExtraDataList::CopyFrom };
-			return func(this, a_extraDataList);
-		}
-
-		static void Create(ExtraDataList* a_extraDataList) noexcept
-		{
-			using func_t = decltype(&ExtraDataList::Create);
-			static REL::Relocation<func_t> func{ ID::ExtraDataList::Create };
-			return func(a_extraDataList);
-		}
-
 		// members
 		BaseExtraList           extraData;    // 08
 		mutable BSReadWriteLock extraRWLock;  // 20

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -235,10 +235,16 @@ namespace RE::ID
 
 	namespace BGSInventoryList
 	{
-		inline constexpr REL::ID FindAndWriteStackDataForItem{ 2194179 };
+		inline constexpr REL::ID AddItem1{ 2194159 };
+		inline constexpr REL::ID AddItem2{ 2194160 };
 		inline constexpr REL::ID BuildFromContainer{ 2194158 };
+		inline constexpr REL::ID Clear{ 2194162 };
 		inline constexpr REL::ID ctor{ 2194153 };
-		inline constexpr REL::ID AddItem{ 2194159 };
+		inline constexpr REL::ID FindAndWriteStackDataForItem{ 2194179 };
+		inline constexpr REL::ID FindItemIndex{ 2194165 };
+		inline constexpr REL::ID GetItemCount{ 2194163 };
+		inline constexpr REL::ID GetQuestItemCount{ 2194164 };
+		inline constexpr REL::ID RemoveItem1{ 2194169 };
 	}
 
 	namespace BGSKeyword
@@ -1002,9 +1008,12 @@ namespace RE::ID
 
 	namespace ExtraDataList
 	{
+		inline constexpr REL::ID CopyList{ 2190094 };
 		inline constexpr REL::ID CreateInstanceData{ 2190185 };
+		inline constexpr REL::ID Ctor{ 2190088 };
 		inline constexpr REL::ID GetLegendaryMod{ 2190180 };
 		inline constexpr REL::ID SetBendableSplineInfo{ 2190623 };
+		inline constexpr REL::ID SetCount{ 2190125 };
 		inline constexpr REL::ID SetDisplayNameFromInstanceData{ 2190179 };
 		inline constexpr REL::ID SetOverrideName{ 2190167 };
 		inline constexpr REL::ID SetStartingWorldOrCell{ 2190506 };

--- a/include/RE/IDs.h
+++ b/include/RE/IDs.h
@@ -238,12 +238,9 @@ namespace RE::ID
 		inline constexpr REL::VariantID FindAndWriteStackDataForItem{ 1354005, 2194179 };
 		inline constexpr REL::VariantID BuildFromContainer{ 551792, 2194158 };
 		inline constexpr REL::VariantID ctor{ 845050, 2194153 };
-		inline constexpr REL::VariantID AddItem{ 19103, 2194159 };
-		inline constexpr REL::VariantID AddItem1{ 19103, 2194159 };       // libxse name for AddItem
-		inline constexpr REL::VariantID AddItemWithExtra{ 98986, 2194160 };
-		inline constexpr REL::VariantID AddItem2{ 98986, 2194160 };       // libxse name for AddItemWithExtra
-		inline constexpr REL::VariantID RemoveItem{ 400062, 2194169 };
-		inline constexpr REL::VariantID RemoveItem1{ 400062, 2194169 };   // libxse name for RemoveItem
+		inline constexpr REL::VariantID AddItem1{ 19103, 2194159 };
+		inline constexpr REL::VariantID AddItem2{ 98986, 2194160 };
+		inline constexpr REL::VariantID RemoveItem1{ 400062, 2194169 };
 		inline constexpr REL::VariantID GetItemCount{ 894081, 2194163 };
 		inline constexpr REL::VariantID GetQuestItemCount{ 800903, 2194164 };
 		inline constexpr REL::VariantID FindItemIndex{ 2111, 2194165 };
@@ -1031,10 +1028,8 @@ namespace RE::ID
 		inline constexpr REL::VariantID CompareList{ 585876, 2190098 };
 		inline constexpr REL::VariantID SetFavorite{ 534268, 2190188 }; // Check
 		inline constexpr REL::VariantID GetPrimitive{ 1271508, 2190427 }; // Check
-		inline constexpr REL::VariantID Create{ 1329859, 2190088 };
-		inline constexpr REL::VariantID Ctor{ 1329859, 2190088 };      // libxse name for Create
-		inline constexpr REL::VariantID CopyFrom{ 561304, 2190094 };
-		inline constexpr REL::VariantID CopyList{ 561304, 2190094 };   // libxse name for CopyFrom
+		inline constexpr REL::VariantID Ctor{ 1329859, 2190088 };
+		inline constexpr REL::VariantID CopyList{ 561304, 2190094 };
 		inline constexpr REL::VariantID SetCount{ 1460465, 2190125 };
 	}
 


### PR DESCRIPTION
Pulls libxse/commonlibf4 main into the fork to add 1.11.221 runtime
support. Absorbs three upstream commits:

- `c84949a8` adds `RUNTIME_1_11_221` and points `RUNTIME_LATEST` at it
- `47317a4c` `ExtraDataList` and `BGSInventoryList` additions and renames (perchik71)
- `de82cf74` whitespace maintenance pass