### PR TITLE
OG/NG compatibility for plugins using the commonlibf4-plugin template

### DIFF
--- a/include/F4SE/Interfaces.h
+++ b/include/F4SE/Interfaces.h
@@ -567,8 +567,10 @@ namespace F4SE
 
 #define F4SE_EXPORT extern "C" [[maybe_unused]] __declspec(dllexport)
 #define F4SE_PLUGIN_PRELOAD(...) F4SE_EXPORT bool F4SEPlugin_Preload(__VA_ARGS__)
+#define F4SE_PLUGIN_QUERY(...) F4SE_EXPORT bool F4SEPlugin_Query(__VA_ARGS__)
 #define F4SE_PLUGIN_LOAD(...) F4SE_EXPORT bool F4SEPlugin_Load(__VA_ARGS__)
 #define F4SE_PLUGIN_VERSION F4SE_EXPORT constinit F4SE::PluginVersionData F4SEPlugin_Version
 #define F4SEPluginPreload F4SE_PLUGIN_PRELOAD
+#define F4SEPluginQuery F4SE_PLUGIN_QUERY
 #define F4SEPluginLoad F4SE_PLUGIN_LOAD
 #define F4SEPluginVersion F4SE_PLUGIN_VERSION

--- a/include/RE/S/SCRIPT_FUNCTION.h
+++ b/include/RE/S/SCRIPT_FUNCTION.h
@@ -18,8 +18,9 @@ namespace RE
 
 		[[nodiscard]] static auto GetConsoleFunctions()
 		{
-			static REL::Relocation<SCRIPT_FUNCTION(*)[523]> functions{ ID::SCRIPT_FUNCTION::ConsoleFunctions };
-			return std::span{ *functions };
+			static REL::Relocation<SCRIPT_FUNCTION*> functions{ ID::SCRIPT_FUNCTION::ConsoleFunctions };
+			const std::size_t size = (REX::FModule::IsRuntimeOG() ? 521 : (REX::FModule::IsRuntimeNG() ? 525 : 523));
+			return std::span<SCRIPT_FUNCTION>{ functions.get(), size };
 		}
 
 		static SCRIPT_FUNCTION* LocateConsoleCommand(const std::string_view a_longName)

--- a/res/commonlibf4-plugin.cpp.in
+++ b/res/commonlibf4-plugin.cpp.in
@@ -6,9 +6,10 @@ F4SE_PLUGIN_VERSION = []() noexcept {
     v.PluginName("${COMMONLIB_PLUGIN_NAME}");
     v.AuthorName("${COMMONLIB_PLUGIN_AUTHOR}");
     v.UsesAddressLibrary(true);
+    v.UsesAddressLibraryNG(true);
     v.UsesSigScanning(false);
     v.IsLayoutDependent(true);
+    v.IsLayoutDependentNG(true);
     v.HasNoStructUse(false);
-    v.CompatibleVersions({ F4SE::RUNTIME_LATEST });
     return v;
 }();

--- a/src/F4SE/API.cpp
+++ b/src/F4SE/API.cpp
@@ -72,6 +72,9 @@ namespace F4SE
 				if (f4seVersion >= REL::Version{ 0, 7, 1, 0 }) {
 					saveFolderName = a_intfc->GetSaveFolderName();
 				}
+				else {
+					saveFolderName = "Fallout4"sv;
+				}
 			});
 		}
 


### PR DESCRIPTION
This allows you to use your fork with:
https://github.com/libxse/commonlibf4-template

Mostly it's not relevant for Addictol itself.  But this may be useful to others that are using your fork.


In order to use with OG in commonlibf4-template you need to define F4SEPlugin_Query as follows:
```cpp
F4SE_PLUGIN_QUERY(const F4SE::QueryInterface* a_f4se, F4SE::PluginInfo* a_info)
{
	if (const auto data = F4SE::PluginVersionData::GetSingleton()) {
		a_info->infoVersion = F4SE::PluginInfo::kVersion;
		a_info->name = data->GetPluginName().data();
		a_info->version = data->GetPluginVersion().pack();
	}

	const auto ver = a_f4se->RuntimeVersion();
	if (ver < REL::Version(F4SE::RUNTIME_1_10_163)) {
		return false;
	}

	return true;
}
```

Other compatibility fixes:
* Default save folder name to Fallout4 on F4SE runtimes less than 0.7.1.0
* Derive the runtime-dependent array size for GetConsoleFunctions()